### PR TITLE
Fix line break before Zenodo link in footer

### DIFF
--- a/resources/overrides/partials/footer.html
+++ b/resources/overrides/partials/footer.html
@@ -98,18 +98,20 @@
 
       <div class="cite-example md-copyright">
         <div class="md-footer-meta__inner md-grid" style="justify-content: center; align-items: center;">
-          Cite as:
-          {% for author in config.citation.authors %}
-            {% set surname = author['family-names'] %}
-            {% set name = author['given-names'] %}
-            {% if loop.last %}
-              {{ surname }}, {{ name }}.
-            {% else %}
-              {{ surname }}, {{ name }},
-            {% endif %}
-          {% endfor %}
-          ({{ config.citation['date-released'] }}). {{ config.citation.title }} ({{ config.citation.version }}). 
-          <a href="https://doi.org/{{ config.citation.doi }}">&nbsp;https://doi.org/{{ config.citation.doi }}</a>
+          <p style="margin: 0px;">
+            Cite as:
+            {% for author in config.citation.authors %}
+              {% set surname = author['family-names'] %}
+              {% set name = author['given-names'] %}
+              {% if loop.last %}
+                {{ surname }}, {{ name }}.
+              {% else %}
+                {{ surname }}, {{ name }},
+              {% endif %}
+            {% endfor %}
+            ({{ config.citation['date-released'] }}). {{ config.citation.title }} ({{ config.citation.version }}). 
+            <a href="https://doi.org/{{ config.citation.doi }}">https://doi.org/{{ config.citation.doi }}</a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
In case of a very long list of authors (or narrow screens), the link to Zenodo at the end of the footer gets put on a new line (see screenshot).

![image](https://github.com/user-attachments/assets/6c4a0aa1-8cff-4a6a-b00b-d7b743a031e1)

This can be fixed by wrapping the whole footer text in a paragraph. To keep the existing format, the margin of this paragraph gets manually set to 0, to not add additional space above and beyond the text.