### PR TITLE
Add GitLab CI/CD pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,258 @@
+##################
+## GLOBAL SETTINGS
+##################
+
+variables:
+  # Project Configuration
+  BRANCH_SOURCE: "main"
+  BRANCH_PAGES: "gl-pages"
+  GIT_DEPTH: 1
+
+  # Version Management
+  UV_PYTHON: "3.13"
+  VERSION_ALPINE: "3.22"
+
+  # Variables which should be defined as CI/CD variables
+  #PUSH_TOKEN: ## DO NOT DEFINE HERE FOR SECURITY REASONS; only define a PUSH_TOKEN if your $CI_JOB_TOKEN is not allowed to push
+
+
+##################
+## PIPELINE STAGES
+##################
+
+stages:
+  - synchronize_metadata
+  - build_docs
+  - deploy_docs
+
+
+##################
+## PIPELINE JOBS
+##################
+
+.rule_is_main_branch: &is_main_branch
+  if: '$CI_COMMIT_BRANCH == $BRANCH_SOURCE'
+
+# Stage: Synchronize Metadata
+synchronize_metadata:
+  stage: synchronize_metadata
+  rules: [*is_main_branch]
+  extends: .job_synchronize_metadata
+
+# Stage: Build Documentation
+build_docs_latest:
+  stage: build_docs
+  rules: [*is_main_branch]
+  variables: {DEPLOYMENT_VERSION_NAME: "latest"}
+  extends: .job_build_docs
+
+# Stage: Deploy Documentation and Upload to Zenodo
+pages:
+  stage: deploy_docs
+  rules: [*is_main_branch]
+  extends: .job_pages
+
+
+##################
+## BASH SNIPPETS
+##################
+
+# Common package installation scripts
+.apk_add_git_and_config: &apk_add_git_and_config
+  - apk add git
+  - git config --global user.email "gitlab-ci[bot]@noreply.gitlab.com"
+  - git config --global user.name "GitLab CI[bot]"
+
+.apk_add_yq: &apk_add_yq
+  - apk add wget
+  - wget --quiet "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" --output-document=/usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+# Git operation scripts
+.git_commit_all_changes: &git_commit_all_changes
+  # Debug information
+  - git diff
+  - git status
+  # Pull latest version of branch
+  - git fetch --depth=1 origin "$COMMIT_BRANCH"
+  - git stash
+  - git switch "$COMMIT_BRANCH"
+  - git pull --depth=1 origin "$COMMIT_BRANCH"
+  - git stash pop || echo "No stash to apply."
+  # Check for changes and commit if needed
+  - |
+    if [ -n "$(git status --porcelain)" ]; then
+      echo "Files have changed. Create commit."
+      git add .
+      git commit --message="$COMMIT_MESSAGE"
+    else
+      echo "No changes to commit."
+    fi
+
+.git_reset_hard_branch: &git_reset_hard_branch
+  # Debug information
+  - git diff
+  - git status
+  # Checkout build branch
+  - git fetch --depth=1 origin "$SWITCH_BRANCH"
+  - git switch --discard-changes "$SWITCH_BRANCH"
+  - git pull --depth=1 origin "$SWITCH_BRANCH"
+  - echo "Successfully checked out $SWITCH_BRANCH"
+
+.git_push: &git_push
+  - |
+    # Test if PUSH_TOKEN is defined as CI/CD variable; otherwise default to $CI_JOB_TOKEN.
+    if [ -z "$PUSH_TOKEN" ]; then
+      echo "No PUSH_TOKEN as CI/CD variable defined. Using CI_JOB_TOKEN."
+      PUSH_TOKEN="$CI_JOB_TOKEN"
+    fi
+  - git push --push-option=ci.skip https://gitlab-ci-token:$PUSH_TOKEN@$CI_SERVER_HOST/$CI_PROJECT_PATH.git "$PUSH_REFSPEC"
+
+
+##################
+## JOB TEMPLATES
+##################
+
+default:
+  image: alpine:$VERSION_ALPINE
+
+####################################################################################################
+
+
+.job_synchronize_metadata:
+
+  before_script:
+    - apk add coreutils  # For avoiding "realpath: --: No such file or directory"
+    - *apk_add_git_and_config
+    - apk add jq
+    - apk add uv
+    - *apk_add_yq
+    - SWITCH_BRANCH="$BRANCH_SOURCE"
+    - *git_reset_hard_branch
+
+  script:
+    # Validate metadata in CITATION.cff
+    - uvx cffconvert --validate
+
+    ## Create .zenodo.json
+
+    # Convert CITATION.cff to Zenodo metadata format
+    - uvx cffconvert --infile CITATION.cff --format zenodo --outfile .zenodo.json
+    # Add Zenodo upload type
+    - jq '.upload_type = "lesson"' .zenodo.json > .zenodo.json.tmp && mv .zenodo.json.tmp .zenodo.json
+    # Fix Zenodo license field in the .zenodo.json metadata, as per new Zenodo requirements
+    - jq '.license = .license.id' .zenodo.json > .zenodo.json.tmp && mv .zenodo.json.tmp .zenodo.json
+    # Enrich Zenodo metadata (if template file exists)
+    - |
+      if [ -f ".github/templates/zenodo_metadata_enrichment.json" ]; then
+        echo "Adding zenodo_metadata_enrichment.json to .zenodo.json..."
+        jq --slurp '.[0] * .[1]' .zenodo.json .github/templates/zenodo_metadata_enrichment.json > .zenodo.json.tmp && mv .zenodo.json.tmp .zenodo.json
+      else
+        echo "Warning: File zenodo_metadata_enrichment.json not found."
+      fi
+
+    ## Update mkdocs.yml
+
+    # Update mkdocs.yml with new CITATION.cff values
+    - "yq eval-all --inplace 'select(fileIndex == 0) * {\"citation\": select(fileIndex == 1)}' mkdocs.yml CITATION.cff"
+    # Extract only year in mkdocs metadata
+    - yq eval-all --inplace '.citation.date-released=(.citation.date-released | split("-"))[0]' mkdocs.yml
+
+    # Construct linkset URL
+    - LINKSET_URL="${CI_PROJECT_URL}/-/raw/${CI_COMMIT_REF_NAME}/linkset.json"
+    - echo "LINKSET_URL=$LINKSET_URL"
+    # Update linkset path in mkdocs.yml
+    - yq eval --inplace ".signposting_linkset=\"${LINKSET_URL}\"" mkdocs.yml
+
+    ## Signposting
+
+    # Read signposting URL from mkdocs.yml
+    - GL_PAGES_URL=$(yq eval '.signposting_gitbook_url' mkdocs.yml)
+    - |
+      # Use URL from CI-Pipeline for pages if nothing is specified in mkdocs.yml
+      if [ -z "$GL_PAGES_URL" -o "$GL_PAGES_URL" == "null" ]; then
+        echo "No signposting_gitbook_url in mkdocs found. Setting site url to $CI_PAGES_URL/$GL_PAGES_VERSION/"
+        GL_PAGES_URL="${CI_PAGES_URL}/latest/"
+      fi
+    - echo "GL_PAGES_URL=$GL_PAGES_URL"
+
+    # Read signposting profile from mkdocs.yml
+    - SIGNPOSTING_PROFILE=$(yq eval '.signposting_default_profile' mkdocs.yml)
+    - |
+      if [ "$SIGNPOSTING_PROFILE" == "null" ]; then
+        SIGNPOSTING_PROFILE=""
+      fi
+    - echo "SIGNPOSTING_PROFILE=$SIGNPOSTING_PROFILE"
+
+    # Extract signposting metadata (modified GH action korvoj/signposting)
+    - |
+      # uv run python .gitlab/scripts/signposting.py
+      uv run \
+        --with requests,pyyaml,wcmatch \
+        python .gitlab/scripts/signposting.py \
+        --default-profile "${SIGNPOSTING_PROFILE}" \
+        --pages-url ${GL_PAGES_URL} \
+        --gl-repository-url ${CI_PROJECT_URL} \
+        --default-branch ${BRANCH_SOURCE}
+
+    # Commit changes
+    - COMMIT_MESSAGE="[CI] Update metadata"
+    - COMMIT_BRANCH="${BRANCH_SOURCE}"
+    - *git_commit_all_changes
+    # Push changes
+    - PUSH_REFSPEC="$COMMIT_BRANCH"
+    - *git_push
+
+####################################################################################################
+
+
+.job_build_docs:
+
+  before_script:
+    - apk add coreutils  # For avoiding "realpath: --: No such file or directory"
+    - *apk_add_git_and_config
+    - apk add uv
+    - SWITCH_BRANCH="$BRANCH_SOURCE"
+    - *git_reset_hard_branch
+
+  script:
+    # Update local copy of branch for pages deployment
+    - git fetch --depth=1 origin "$BRANCH_PAGES" || echo "Nothing to fetch for remote branch $BRANCH_PAGES"
+
+    # Deploy documentation version
+    - |
+      # uv run mike deploy
+      uv run \
+        --with-requirements requirements.txt \
+        mike deploy \
+        --push \
+        --update-aliases \
+        --branch $BRANCH_PAGES \
+        --deploy-prefix public \
+        $DEPLOYMENT_VERSION_NAME
+
+    # Set default version
+    - |
+      # uv run mike set-default
+      uv run \
+        --with-requirements requirements.txt \
+        mike set-default \
+        --push \
+        --branch $BRANCH_PAGES \
+        --deploy-prefix public \
+        latest
+
+####################################################################################################
+
+.job_pages:
+
+  before_script:
+    - *apk_add_git_and_config
+    - SWITCH_BRANCH="$BRANCH_PAGES"
+    - *git_reset_hard_branch
+  script:
+    # Debug information
+    - ls -lh public
+    # No need to do anything further, GitLab Pages picks up the content of the 'public/' folder and deploys them to GitLab Pages
+  artifacts:
+    paths:
+      - public/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,9 @@ variables:
 
   # Variables which should be defined as CI/CD variables
   #PUSH_TOKEN: ## DO NOT DEFINE HERE FOR SECURITY REASONS; only define a PUSH_TOKEN if your $CI_JOB_TOKEN is not allowed to push
+  #ZENODO_USE_SANDBOX: "true"
+  #ZENODO_ACCESS_TOKEN:  ## DO NOT DEFINE HERE FOR SECURITY REASONS
+  #ZENODO_SANDBOX_ACCESS_TOKEN:  ## DO NOT DEFINE HERE FOR SECURITY REASONS
 
 
 ##################
@@ -21,6 +24,7 @@ variables:
 ##################
 
 stages:
+  - prepare_release
   - synchronize_metadata
   - build_docs
   - deploy_docs
@@ -33,24 +37,45 @@ stages:
 .rule_is_main_branch: &is_main_branch
   if: '$CI_COMMIT_BRANCH == $BRANCH_SOURCE'
 
-# Stage: Synchronize Metadata
+.rule_is_release_tag: &is_release_tag
+  if: '$CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/'
+
+# Stage 1: Reserve DOI
+prepare_release:
+  stage: prepare_release
+  rules: [*is_release_tag]
+  extends: .job_prepare_release
+
+# Stage 2: Synchronize Metadata
 synchronize_metadata:
   stage: synchronize_metadata
-  rules: [*is_main_branch]
+  rules: [*is_release_tag, *is_main_branch]
   extends: .job_synchronize_metadata
 
-# Stage: Build Documentation
+# Stage 3: Build Documentation
 build_docs_latest:
   stage: build_docs
-  rules: [*is_main_branch]
+  rules: [*is_release_tag, *is_main_branch]
   variables: {DEPLOYMENT_VERSION_NAME: "latest"}
   extends: .job_build_docs
 
-# Stage: Deploy Documentation and Upload to Zenodo
+build_docs_release:
+  stage: build_docs
+  rules: [*is_release_tag]
+  needs: ["build_docs_latest"]
+  variables: {DEPLOYMENT_VERSION_NAME: "$CI_COMMIT_TAG"}
+  extends: .job_build_docs
+
+# Stage 4: Deploy Documentation and Upload to Zenodo
 pages:
   stage: deploy_docs
-  rules: [*is_main_branch]
+  rules: [*is_release_tag, *is_main_branch]
   extends: .job_pages
+
+upload_zenodo:
+  stage: deploy_docs
+  rules: [*is_release_tag]
+  extends: .job_upload_zenodo
 
 
 ##################
@@ -66,6 +91,10 @@ pages:
 .apk_add_yq: &apk_add_yq
   - apk add wget
   - wget --quiet "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" --output-document=/usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+.apk_add_zenodraft: &apk_add_zenodraft
+  - apk add npm
+  - npm install --global zenodraft
 
 # Git operation scripts
 .git_commit_all_changes: &git_commit_all_changes
@@ -107,6 +136,17 @@ pages:
     fi
   - git push --push-option=ci.skip https://gitlab-ci-token:$PUSH_TOKEN@$CI_SERVER_HOST/$CI_PROJECT_PATH.git "$PUSH_REFSPEC"
 
+# Zenodo configuration
+.configure_zenodo_server: &configure_zenodo_server
+  - |
+    if [ "$ZENODO_USE_SANDBOX" == "true" ]; then
+      ZENODO_SANDBOX_FLAG="--sandbox"
+      echo "Using Zenodo sandbox environment"
+    else
+      ZENODO_SANDBOX_FLAG=""
+      echo "Using Zenodo production environment"
+    fi
+
 
 ##################
 ## JOB TEMPLATES
@@ -118,12 +158,91 @@ default:
 ####################################################################################################
 
 
+.job_prepare_release:
+
+  before_script:
+    - apk add coreutils  # For avoiding "realpath: --: No such file or directory"
+    - *apk_add_git_and_config
+    - apk add uv
+    - *apk_add_yq
+    - *apk_add_zenodraft
+    - *configure_zenodo_server
+
+  script:
+    # Make sure that the source branch is up-to-date with the release tag (otherwise changes could get lost)
+    - git fetch --depth=1 origin "$BRANCH_SOURCE"
+    - |
+      if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/$BRANCH_SOURCE)" ]; then
+        echo "Release tag ($CI_COMMIT_TAG) ist not in sync with branch ($BRANCH_SOURCE)."
+        echo "Please push the branch and let the pipeline finish before creating a release tag."
+        exit 11
+      fi
+
+    # Get current DOI from CITATION.cff
+    - DOI_CURRENT="$(yq eval '.doi' CITATION.cff)"
+    - echo "DOI_CURRENT=$DOI_CURRENT"
+
+    # Get Zenodo collection id
+    - |
+      ZENODO_COLLECTION_ID=$(\
+        DOI="$DOI_CURRENT" \
+        ZENODO_SANDBOX="$ZENODO_USE_SANDBOX" \
+        uv run \
+          --with requests \
+          python .github/scripts/get_zenodo_collection.py \
+        )
+    - echo "ZENODO_COLLECTION_ID=$ZENODO_COLLECTION_ID"
+
+    # Create new Zenodo record
+    - |
+      if [ -n "$ZENODO_COLLECTION_ID" ]; then
+        echo "Creating new version of existing collection..."
+        ZENODO_VERSION_ID=$(zenodraft deposition create version $ZENODO_COLLECTION_ID $ZENODO_SANDBOX_FLAG) \
+          || ( echo "ERROR: Failed to create new version. Possible causes:" \
+                    "- An open draft already exists for this collection on Zenodo" \
+                    "- Network connectivity issues" \
+                    "- Invalid access token" \
+                    "Please check Zenodo dashboard and try again." \
+              && exit 12 )
+      else
+        # If this is the first release, create a new Zenodo record collection/concept
+        echo "Creating new collection (first release)..."
+        ZENODO_VERSION_ID=$(zenodraft deposition create concept $ZENODO_SANDBOX_FLAG)
+      fi
+    - echo "ZENODO_VERSION_ID=$ZENODO_VERSION_ID"
+
+    # Get prereserved DOI
+    - DOI_PRERESERVED=$(zenodraft deposition show prereserved $ZENODO_SANDBOX_FLAG $ZENODO_VERSION_ID)
+    - echo "DOI_PRERESERVED=$DOI_PRERESERVED"
+
+    # Update DOI in CITATION.cff
+    - yq eval --inplace ".doi = \"$DOI_PRERESERVED\"" CITATION.cff
+
+    # Get current date
+    - CURRENT_DATE=$(date '+%Y-%m-%d')
+    # Update date-released in CITATION.cff
+    - yq eval --inplace ".date-released=\"${CURRENT_DATE}\"" CITATION.cff
+    # Update version in CITATION.cff
+    - yq eval --inplace ".version=\"${CI_COMMIT_TAG}\"" CITATION.cff
+
+    # Commit changes
+    - COMMIT_MESSAGE="[CI] Update CITATION.cff with prereserved Zenodo DOI"
+    - COMMIT_BRANCH="${BRANCH_SOURCE}"
+    - *git_commit_all_changes
+    # Push changes
+    - PUSH_REFSPEC="$COMMIT_BRANCH"
+    - *git_push
+
+####################################################################################################
+
+
 .job_synchronize_metadata:
 
   before_script:
     - apk add coreutils  # For avoiding "realpath: --: No such file or directory"
     - *apk_add_git_and_config
     - apk add jq
+    - apk add sed
     - apk add uv
     - *apk_add_yq
     - SWITCH_BRANCH="$BRANCH_SOURCE"
@@ -194,6 +313,19 @@ default:
         --gl-repository-url ${CI_PROJECT_URL} \
         --default-branch ${BRANCH_SOURCE}
 
+    ## DOI synchronisation
+
+    # Get DOI from CITATION.cff
+    - DOI_PRERESERVED=$(yq eval '.doi' CITATION.cff)
+
+    # Update DOI in index.md
+    - DOI_OLD=$(grep 'urlToResource:' resources/index.md | grep -o -E '[0-9]+\.[0-9]+/.*\.[0-9]+')
+    - echo "DOI_OLD=$DOI_OLD"
+    - sed -i --follow-symlinks "s@$DOI_OLD@$DOI_PRERESERVED@g" resources/index.md
+
+    # Update DOI in PowerPoint files
+    - uv run --with pyyaml,python-pptx python .github/scripts/update_doi_pptx.py
+
     # Commit changes
     - COMMIT_MESSAGE="[CI] Update metadata"
     - COMMIT_BRANCH="${BRANCH_SOURCE}"
@@ -256,3 +388,28 @@ default:
   artifacts:
     paths:
       - public/
+
+####################################################################################################
+
+
+.job_upload_zenodo:
+
+  before_script:
+    - *apk_add_git_and_config
+    - *apk_add_zenodraft
+    - SWITCH_BRANCH="$BRANCH_SOURCE"
+    - *git_reset_hard_branch
+    - *configure_zenodo_server
+
+  script:
+    # Extract ZENODO_VERSION_ID from CITATION.cff (number after last .)
+    - "ZENODO_VERSION_ID=$(sed -n -e 's/^doi: .*\\.//p' CITATION.cff)"
+    - echo "ZENODO_VERSION_ID=$ZENODO_VERSION_ID"
+
+    # Upload the metadata from .zenodo.json
+    - zenodraft metadata update $ZENODO_SANDBOX_FLAG $ZENODO_VERSION_ID .zenodo.json
+
+    # Upload contents to Zenodo
+    - ZIP_FILENAME_SOURCE="${CI_PROJECT_NAME}__$(git rev-parse --short HEAD).zip"
+    - git archive --output="$ZIP_FILENAME_SOURCE" "$BRANCH_SOURCE"
+    - zenodraft file add $ZENODO_SANDBOX_FLAG $ZENODO_VERSION_ID "$ZIP_FILENAME_SOURCE"

--- a/.gitlab/scripts/signposting.py
+++ b/.gitlab/scripts/signposting.py
@@ -1,0 +1,175 @@
+"""
+This script is based on https://github.com/korvoj/signposting/blob/1.0.1/entrypoint.py
+
+It has been modified to cover GitLab Pages instead of GitHub Pages.
+"""
+import json
+import os
+import urllib.parse
+import argparse
+import yaml
+from wcmatch import glob
+import requests
+
+argument_parser = argparse.ArgumentParser(description='Signposting linkset generator')
+argument_parser.add_argument('--default-branch', type=str, default='main')
+argument_parser.add_argument('--default-profile', type=str, required=True)
+argument_parser.add_argument('--exclusions-file', type=str, default='mkdocs.yml')
+argument_parser.add_argument('--root-dir', type=str, default='resources')
+argument_parser.add_argument('--gl-repository-url', type=str, required=True)
+argument_parser.add_argument('--pages-url', type=str, required=True)
+args = argument_parser.parse_args()
+
+DEFAULT_BRANCH = args.default_branch
+PAGES_URL = args.pages_url
+DEFAULT_PROFILE_DISCOVERED_ITEMS = args.default_profile
+EXCLUSIONS_FILE_PATH = args.exclusions_file
+ROOT_DIR_PATH = args.root_dir
+GITLAB_REPOSITORY_URL = args.gl_repository_url
+BLOB_CONTENT_URL = f'{GITLAB_REPOSITORY_URL}/-/blob'
+RAW_CONTENT_URL = f'{GITLAB_REPOSITORY_URL}/-/raw'
+
+
+class SignPost:
+    def __init__(self, href, type=None, profile=None):
+        self.href = href
+        self.type = type
+        self.profile = profile
+
+    def __repr__(self):
+        str_representation = f'href: {self.href}'
+        if self.type is not None:
+            str_representation += f' type: {self.type}'
+        if self.profile is not None:
+            str_representation += f' profile: {self.profile}'
+        return str_representation
+
+    def to_json(self):
+        json_representaton = dict()
+        json_representaton['href'] = self.href
+        if self.type is not None:
+            json_representaton['type'] = self.type
+        if self.profile is not None and str.strip(self.profile) != '':
+            json_representaton['profile'] = self.profile
+        return json_representaton
+
+
+def read_exclusions_file(exclusions_file_path):
+    with open(exclusions_file_path) as stream:
+        try:
+            yaml_exclusions = yaml.safe_load(stream)
+            return yaml_exclusions.get('signposting_exclusions', [])
+        except yaml.YAMLError as err:
+            print('An error has occurred: ', err)
+
+
+def fetch_files(root_dir, exclusions):
+    url_list = []
+    markdown_files = glob.glob(patterns='**/**.md', root_dir=root_dir,
+                               exclude=exclusions, flags=glob.GLOBSTAR)
+    for markdown_file in markdown_files:
+        # print(markdown_file)
+        url_encoded_path = urllib.parse.quote(markdown_file)
+        if root_dir and root_dir != '':
+            url_list.append(
+                f'{BLOB_CONTENT_URL}/{DEFAULT_BRANCH}/{root_dir}/{url_encoded_path}')
+        else:
+            url_list.append(
+                f'{BLOB_CONTENT_URL}/{DEFAULT_BRANCH}/{url_encoded_path}')
+
+    return url_list
+
+
+def parse_citation_cff_authors(citation_cff):
+    orcids = [SignPost(href=i['orcid'], type=None) for i in citation_cff.get('authors', []) if
+              i.get('orcid') is not None]
+    return orcids
+
+
+def parse_citation_cff_license(citation_cff):
+    response = requests.get('https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json')
+    if response.status_code != 200:
+        print('Error fetching license list, status code: ', response.status_code)
+        return
+    license_list = response.json().get('licenses', [])
+    cff_license = citation_cff.get('license')
+    if cff_license is not None:
+        for i in license_list:
+            if i.get('licenseId', '') == cff_license:
+                return SignPost(href=i.get('reference'), type=None)
+    raise Exception('No license mapping to SPDX possible')
+
+
+def parse_citation_cff_repository(citation_cff):
+    repository_url = citation_cff.get('repository')
+    return SignPost(href=repository_url, type='text/html')
+
+
+def parse_citation_cff_related(citation_cff):
+    doi = citation_cff.get('doi', '')
+    doi = f'https://doi.org/{doi}'
+    return SignPost(href=doi, type='text/html')
+
+
+def construct_types():
+    return [
+        SignPost(href='https://schema.org/LearningResource', type=None),
+        SignPost(href='https://schema.org/AboutPage', type=None)
+    ]
+
+
+def construct_described_by():
+    return [
+        SignPost(type='application/yaml', profile='https://citation-file-format.github.io/1.2.0/schema.json',
+                 href=f'{RAW_CONTENT_URL}/{DEFAULT_BRANCH}/CITATION.cff')
+    ]
+
+
+def construct_items(files):
+    signposts = []
+    for file in files:
+        signpost = SignPost(href=file, type='text/markdown', profile=DEFAULT_PROFILE_DISCOVERED_ITEMS)
+        signposts.append(signpost)
+    return signposts
+
+
+def generate_linkset(root_dir, exclusions):
+    citation_cff = ''
+    with open('CITATION.cff') as stream:
+        try:
+            citation_cff = yaml.safe_load(stream)
+        except yaml.YAMLError as err:
+            print('An error has occurred: ', err)
+            return
+    authors = parse_citation_cff_authors(citation_cff)
+    spdx_license = parse_citation_cff_license(citation_cff)
+    item_repository_url = parse_citation_cff_repository(citation_cff)
+    related = parse_citation_cff_related(citation_cff)
+    types = construct_types()
+    described_by = construct_described_by()
+    discovered_files = fetch_files(root_dir=root_dir, exclusions=exclusions)
+    all_items = construct_items(discovered_files)
+    all_items.append(item_repository_url)
+
+    json_linkset = {
+        'linkset': [
+            {
+                'anchor': PAGES_URL,
+                'type': [i.to_json() for i in types],
+                'author': [i.to_json() for i in authors],
+                'item': [i.to_json() for i in all_items],
+                'describedby': [i.to_json() for i in described_by],
+                'license': [spdx_license.to_json()],
+                'related': [related.to_json()]
+            }
+        ]
+    }
+
+    with open('linkset.json', 'w') as f:
+        json.dump(json_linkset, f)
+    # print(json_linkset)
+
+
+if __name__ == '__main__':
+    exclusions = read_exclusions_file(EXCLUSIONS_FILE_PATH)
+    generate_linkset(root_dir=ROOT_DIR_PATH, exclusions=exclusions)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,50 @@ If you are interested in following the training as a learner:
 
 If you want to start developing FAIR-by-Design learning materials based on these templates simply clone this repository.
 
+### Gitlab Pages
+
+This repo contains a `.gitlab-ci.yml` file for automatically deploying the content of this repo to [Gitlab Pages](https://docs.gitlab.com/ee/user/project/pages/).
+
+#### Available workflows
+
+The included `.gitlab-ci.yml` file provides 2 workflows:
+
+##### Push to main branch during development
+
+On each push to the main branch, the CI/CD pipeline will
+
+- automatically synchronise the metadata between `CITATION.cff`, `mkdocs.yml`, `.zenodo.json`, and `linkset.json` and
+- build and deploy the MkDocs document to GitLab pages under `/latest/`.
+
+##### Create a release
+
+If you create a [tag](https://docs.gitlab.com/user/project/repository/tags/) in the [Semantic Versioning](https://semver.org/) format `[number].[number].[number]` (e.g. 1.0.0; see the [Fair-by-Design Train of Trainers unit "Zenodo Publishing"](https://fair-by-design-methodology.github.io/FAIR-by-Design_ToT/latest/Stage%205%20%E2%80%93%20Publish/17-Zenodo%20Publishing/17-Zenodo%20Publishing/) for more information about Semantic Versioning), the CI/CD pipeline will
+
+- reserve a DOI on Zenodo,
+- synchronise the current date and version number from the tag into the `CITATION.cff`,
+- run the above steps from the pipeline that runs on a push to main branch (synchronize metadata and deploy latest version to GitLab pages),
+- build and deploy the MkDocs document to GitLab pages under `/<semantic-version-number>/`, and
+- populate the Zenodo entry with the metadata from the repo and a snapshot of the current contents of this repository.
+
+#### Setup the GitLab CI/CD pipeline
+
+To setup the CI/CD pipeline, you need to complete the following steps:
+
+- Make sure the [project feaures](https://docs.gitlab.com/ee/user/project/settings/) `CI/CD` and `Pages` are activated in your project (*Settings* > *General* > *Visibility, project features, permissions*).
+- Allow the pipeline to push content back to the repository (*Settings* > *CI/CD Settings* > *Job token permissions* > *Additional permissions* > *Allow Git push requests to the repository*).
+- Create a [Zenodo Access Token](https://zenodo.org/account/settings/applications/tokens/new/) and save it in GitLab under *Settings* > *CI/CD* > *Variables* > *CI/CD Variables* > *Add variable* with the following properties:
+  - Type: Variable (default)
+  - Environments: All (default)
+  - Visibility: Masked and hidden
+  - Flags:
+    - Protect variable: No (if you want to increase the security and activate this protection, you need to create a rule that all release tags are marked as [protected tags]())
+    - Expand variable reference: No
+  - Key: ZENODO_ACCESS_TOKEN
+  - Value: `<your-access-token>`
+- If you want to use the Zenodo Sandbox for testing, save the access token for the Sandbox as described above, but with the Key `ZENODO_SANDBOX_ACCESS_TOKEN` and create another variable with the key `ZENODO_USE_SANDBOX` and the value `true`.
+
+If the pipelines are still not working, make sure that there is at least [one active runner](https://docs.gitlab.com/ee/ci/runners/runners_scope.html) (navigate to *Settings* > *CI/CD Settings* > *Runners*).
+
 ---
 
 May your learning materials always be FAIR!


### PR DESCRIPTION
This pull request adds a GitLab CI/CD pipeline. Similar to the GitHub Actions pipeline in this repository, the pipeline automatically builds and deploys the training content to GitLab Pages and creates a Zenodo release.

The structure of the GitLab CI/CD pipeline differs a slightly from the GitHub Actions', so some minor deviations in the result are possible. This is due to different features (e.g. GitLab only checks for changes compared to the last commit, not the last push to the branch, making this rule for exection useless).